### PR TITLE
Add spill to S3 (and split) functionality

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,18 +2,13 @@ FROM python:3.8-slim AS build
 
 # Set our workdir
 WORKDIR /app
-RUN mkdir /app/src
-
-# Copy requirements and pip install for great caching
-COPY requirements.txt /app/requirements.txt
-COPY setup.py /app/setup.py
 
 # Get ready to build
 RUN pip install build
-RUN pip install -r requirements.txt
 
 # Now copy the app over and build a wheel
-COPY . /app
+COPY src /app/src
+COPY pyproject.toml setup.cfg /app/
 RUN python -m build
 
 ## Now use the compiled wheel in our lambda function
@@ -21,10 +16,10 @@ FROM public.ecr.aws/lambda/python:3.8 AS lambda
 
 ENV TARGET_BUCKET=replace_me
 
-COPY --from=build /app/dist/unoffical_athena_federation_sdk-0.0.0-py3-none-any.whl /
-RUN pip install /unoffical_athena_federation_sdk-0.0.0-py3-none-any.whl
+COPY --from=build /app/dist/unoffical_athena_federation_sdk-*-py3-none-any.whl /
+RUN pip install /unoffical_athena_federation_sdk-*-py3-none-any.whl
 
-COPY src/handler.py ./
+COPY example/ ./
 RUN ls ./
 
 CMD [ "handler.lambda_handler" ]

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ You can test your Lambda function locally using Lambda Docker images.
 First, build our Docker image and run it.
 
 ```shell
-docker build -t local/athena-python-sdk .
-docker run --rm -p 9000:8080 local/athena-python-sdk
+docker build -t local/athena-python-example .
+docker run --rm -p 9000:8080 local/athena-python-example
 ```
 
 Then, we can execute a sample `PingRequest`.
@@ -84,7 +84,7 @@ aws ecr create-repository --repository-name athena_example --image-scanning-conf
 3. Push tag the image with the repo name and push it up
 
 ```shell
-docker tag athena_example:latest ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/athena_example:${IMAGE_TAG}
+docker tag local/athena-python-example ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/athena_example:${IMAGE_TAG}
 aws ecr get-login-password | docker login --username AWS --password-stdin ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com
 docker push ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/athena_example:${IMAGE_TAG}
 ```
@@ -139,6 +139,7 @@ aws lambda create-function \
     --code ImageUri=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/athena_example:${IMAGE_TAG} \
     --environment 'Variables={TARGET_BUCKET=<BUCKET_NAME>}' \
     --description "Example Python implementation for Athena Federated Queries" \
+    --timeout 60 \
     --package-type Image
 ```
 

--- a/example/handler.py
+++ b/example/handler.py
@@ -1,20 +1,21 @@
 import os
+import json
 
 from athena.federation.lambda_handler import AthenaLambdaHandler
-from athena.federation.athena_data_source import AthenaDataSource
+from sample_data_source import SampleDataSource
 
 # This needs to be a valid bucket that the Lambda function role has access to
 spill_bucket = os.environ['TARGET_BUCKET']
 
 example_handler = AthenaLambdaHandler(
-    data_source=AthenaDataSource(),
+    data_source=SampleDataSource(),
     spill_bucket=spill_bucket
 )
 
 def lambda_handler(event, context):
     # For debugging purposes, we print both the event and the response :)
-    print(event)
+    print(json.dumps(event))
     response = example_handler.process_event(event)
-    print(response)
+    print(json.dumps(response))
 
     return response

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ packages = find:
 python_requires = ~=3.8
 install_requires =
     pyarrow==0.16.0
+    smart-open==5.2.1
 
 [options.packages.find]
 where = src

--- a/src/athena/federation/athena_data_source.py
+++ b/src/athena/federation/athena_data_source.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Mapping
+from typing import Any, Dict, List, Mapping, Union, Generator
 
 import pyarrow as pa
 
@@ -73,10 +73,12 @@ class AthenaDataSource(ABC):
         return []
     
     @abstractmethod
-    def records(self, database_name: str, table_name: str, split: Mapping[str,str]) -> Dict[str,List[Any]]:
+    def records(self, database_name: str, table_name: str, split: Mapping[str,str]) -> Union[Dict[str,List[Any]], Generator[Dict[str,List[Any]],None,None]]:
         """
         Return a dictionary of records for the given table and split.
 
         The dictionary must have the column names as the keys and column data as a list.
+
+        Either a single batch of records can be returned or a generator of records.
         """
         pass

--- a/src/athena/federation/batch_writer.py
+++ b/src/athena/federation/batch_writer.py
@@ -1,0 +1,60 @@
+from typing import Dict, List
+
+import pyarrow as pa
+from smart_open import open
+
+SPILL_THRESHOLD_BYTES = 5 * 1024 * 1024  # 5MB
+
+
+class BatchWriter:
+    """
+    BatchWriter provides an interface to stream PyArrow records to a RecordBatch.
+
+    If the Batch gets too big (>6mb), it will automatically get written to S3.
+    If not, the data is returned directly to the Lambda function.
+    """
+
+    def __init__(self, spill_config: Dict, schema: pa.Schema) -> None:
+        self._spill_config = spill_config
+        self._schema = schema
+        self._spilled = False
+        self._sink = pa.BufferOutputStream()
+        self._writer = pa.RecordBatchStreamWriter(self._sink, self._schema)
+        self._batch_size = 0
+
+    @property
+    def spilled(self) -> bool:
+        return self._spilled
+
+    def write_rows(self, data: Dict):
+        record_batch = pa.RecordBatch.from_arrays(
+            [pa.array(data[name]) for name in self._schema.names],
+            schema=self._schema,
+        )
+        self._batch_size += record_batch.nbytes
+        self._writer.write_batch(record_batch)
+
+    def _build_spill_uri(self):
+        return (
+            f"s3://{self._spill_config['bucket']}/{self._spill_config['key']}/spill.0"
+        )
+
+    def close(self):
+        print(f"Total bytes: {self._batch_size}")
+        self._writer.close()
+        # For now, if we're over 5mb of data, spill everything to s3.
+        # I don't know how to do this without just serializing the whole thing.
+        # If I use `RecordBatchStreamWriter`, it adds a schema IPC message when it doesn't need it.
+        # Perhaps upgrading Arrow will help, but for now...let's do this.
+        if self._batch_size > SPILL_THRESHOLD_BYTES:
+            self._spilled = True
+            with open(self._build_spill_uri(), "wb") as fout:
+                fout.write(self.all_records().serialize())
+
+    def all_records(self):
+        buf = self._sink.getvalue()
+        reader = pa.ipc.open_stream(buf)
+        record_batches = [b for b in reader]
+        one_chunk_table = pa.Table.from_batches(record_batches).combine_chunks()
+        batches = one_chunk_table.to_batches(max_chunksize=None)
+        return batches[0]

--- a/src/athena/federation/models.py
+++ b/src/athena/federation/models.py
@@ -169,3 +169,21 @@ class ReadRecordsResponse:
             },
             "requestType": self.request_type
         }
+
+class RemoteReadRecordsResponse:
+    request_type = 'READ_RECORDS'
+
+    def __init__(self, catalogName, schema, remoteBlocks, encryptionKey) -> None:
+        self.catalogName = catalogName
+        self.schema = schema
+        self.remoteBlocks = remoteBlocks
+        self.encryptionKey = encryptionKey
+
+    def as_dict(self):
+        return {
+            "@type": "RemoteReadRecordsResponse",
+            "catalogName": self.catalogName,
+            "schema": {"schema": AthenaSDKUtils.encode_pyarrow_object(self.schema)},
+            "remoteBlocks": [self.remoteBlocks],
+            "encryptionKey": None
+        }

--- a/src/athena/federation/utils.py
+++ b/src/athena/federation/utils.py
@@ -17,6 +17,7 @@ class AthenaSDKUtils:
         return pa.read_schema(pa.BufferReader(base64.b64decode(b64_schema)))
 
     def encode_pyarrow_records(pya_schema, record_hash):
+        # This is basically the same as pa.record_batch(data, names=['c0', 'c1', 'c2'])
         return pa.RecordBatch.from_arrays(
             [pa.array(record_hash[name]) for name in pya_schema.names],
             schema=pya_schema,
@@ -37,6 +38,6 @@ class AthenaSDKUtils:
         return {
             "@type": "S3SpillLocation",
             "bucket": bucket_name,
-            "key": f"bucket_path/f{str(uuid4())}",
+            "key": f"{bucket_path}/f{str(uuid4())}",
             "directory": True,
         }


### PR DESCRIPTION
- Split functionality was not finished. But now split properties are passed to `self.data_source.records`.
- After much trial and error, I've successfully...but perhaps not efficiently...added Spill to S3 functionality.

Closes #3 and #6 