### PR TITLE
Use Docker Hub instead of public ECR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY pyproject.toml setup.cfg /app/
 RUN python -m build
 
 ## Now use the compiled wheel in our lambda function
-FROM public.ecr.aws/lambda/python:3.8 AS lambda
+FROM amazon/aws-lambda-python:3.8.2021.12.09.15 AS lambda
 
 ENV TARGET_BUCKET=replace_me
 


### PR DESCRIPTION
public ECR  requires authentication.
I updated the Dockerfile with the public Docker Hub image instead.